### PR TITLE
Change default encoding to UTF-8

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -144,7 +144,7 @@ def __add_to_code_blocks(code_blocks, locations, line):
 
 
 def map_md_to_code_blocks(filename, separator):
-    md_file = open(filename, "r")
+    md_file = open(filename, "r", encoding="utf8")
     lines = md_file.readlines()
     locations = None
     code_blocks = {}
@@ -210,7 +210,7 @@ def save_to_file(code_blocks, verbose=False, force=False, output_dest=None):
             if overwrite != "" and overwrite.lower() != "y":
                 continue
 
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf8") as f:
             f.write(value)
             f.close()
 

--- a/md_tangle/save.py
+++ b/md_tangle/save.py
@@ -32,7 +32,7 @@ def save_to_file(code_blocks, verbose=False, force=False, output_dest=None):
             if overwrite != "" and overwrite.lower() != "y":
                 continue
 
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf8") as f:
             f.write(value)
             f.close()
 

--- a/md_tangle/tangle.py
+++ b/md_tangle/tangle.py
@@ -34,7 +34,7 @@ def __add_to_code_blocks(code_blocks, locations, line):
 
 
 def map_md_to_code_blocks(filename, separator):
-    md_file = open(filename, "r")
+    md_file = open(filename, "r", encoding="utf8")
     lines = md_file.readlines()
     locations = None
     code_blocks = {}


### PR DESCRIPTION
Hi, I noticed that, on Windows, the default `open` encoding is not UTF-8 and so md-tangle wouldn't open the file properly when I had emojis or any Unicode specific characters. I changed the various open statements within the code so that it defaults to UTF-8 so I hope that would be fine (I left the README open statement alone b/c that file didn't have Unicode). I understand if you want to find a different way to make the encoding system more flexible though (Like passing in arguments to change it or something).

Thanks for the cool tool though